### PR TITLE
[fix] 지도에서 boardId null 이슈 해결

### DIFF
--- a/lib/data/models/board.dart
+++ b/lib/data/models/board.dart
@@ -25,7 +25,7 @@ class Board {
 
   factory Board.fromJson(Map<String, dynamic> json) {
     return Board(
-      boardId: json['boardId'],
+      boardId: json['boardId'] ?? '',
       type: json['type'],
       title: json['title'],
       content: json['content'],

--- a/lib/data/repositories/board_repository.dart
+++ b/lib/data/repositories/board_repository.dart
@@ -18,8 +18,8 @@ class BoardRepository {
       final docs = result.docs;
       return docs.map((doc) {
         final map = doc.data();
-        doc.id;
-        final newMap = {'boardId': doc.id, ...map};
+        final newMap = {...map, 'boardId': doc.id};
+        // ...map이 되에 오면 map 안에 boardId 값이 덮어쓸 수 있기 때문에 순서 바꿔주기
         return Board.fromJson(newMap);
       }).toList();
     } catch (e) {


### PR DESCRIPTION
### 🚀 개요
지도에서 boardId 에 null이 들어가는 이슈 해결

### 🔧 변경사항
- board model에서 boardId ?? '' 처리
- ...map 순서를 바꿈

### 💡issue : #111  